### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
 
       - run: yarn
 


### PR DESCRIPTION
It seems that the [CI failed ](https://github.com/calebcurtis8/colorful-ear-trainer/actions/runs/10684367340/job/29614626359#step:4:19) due to an older version of Node it's running:

```
error init-package-json@6.0.3: The engine "node" is incompatible with this module. Expected version "^16.14.0 || >=18.0.0". Got "12.22.12"
error Found incompatible module.
```


This change updates node from v12.x to v16.x, the lowest version that this particular package is expecting. We could also bump it up higher (my local environment is at v22.x for example), but whatever you feel comfortable!

Hopefully, this is the only thing we need to update 🤞🏼