### PR TITLE
Fix: noteset selection and extra events

### DIFF
--- a/src/scripts/transpose.js
+++ b/src/scripts/transpose.js
@@ -93,7 +93,6 @@ class KeySelector extends HTMLElement {
 
     if (this.set[selectedIndex]) {
       this.set.value = this.set[selectedIndex].value
-      this.set.dispatchEvent(new CustomEvent('change', { bubbles: true, detail: 'transpose' }))
     }
   }
 }

--- a/src/scripts/user.js
+++ b/src/scripts/user.js
@@ -141,7 +141,14 @@ class DefineUser extends HTMLElement {
         content = content + append
       }
       elm.innerHTML = content
-
+    })
+    // set input values
+    Object.entries(level).forEach(entry => {
+      if(entry[0] === 'set') {
+        // catch note set updates
+        this.setChange({ target: { value: entry[1] }})
+        return
+      }
       const input = document.querySelector(`[name=${entry[0]}]`)
       if (!input) return
       // window scoped function...


### PR DESCRIPTION
Fix(user.js): when selecting note sets in "Levels/Play" mode - the note set and cadence/tonality was not getting changed. Separating the forEach loops to update the input elements separately from the display elements fixes the issue.

Fix (transpose.js): Remove event dispatch that was creating extra events on change